### PR TITLE
Install additional gems.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN apk add --no-cache --update build-base ruby-dev ruby && \
     apk add glibc-2.23-r3.apk && \
     chmod +x packer-post-processor-vagrant-s3 packer-provisioner-serverspec && \
     mv packer-post-processor-vagrant-s3 packer-provisioner-serverspec /bin && \
-    gem install io-console bundler --no-ri --no-rdoc && \
+    gem install io-console bundler rake rspec serverspec --no-ri --no-rdoc && \
     cd /tmp && \
     rm -rf /tmp/build
 

--- a/circle.yml
+++ b/circle.yml
@@ -15,41 +15,29 @@ dependencies:
 
 test:
   override:
-    - docker run --rm unifio/packer version
-    - docker create -v /ruby_gems --name gems busybox
+    - docker run unifio/packer version
     - |
-      docker run --volumes-from gems \
-                 --entrypoint /bin/sh \
-                 -e "GEM_HOME=/ruby_gems" \
-                 -v `pwd`:/data \
-                 -w /data/uat \
-                 --rm unifio/packer -c "bundle install"
-    - |
-      docker run --volumes-from gems \
-                 -e "GEM_HOME=/ruby_gems" \
-                 -e LOCAL_USER_ID=$UID \
+      docker run -e LOCAL_USER_ID=$UID \
                  -e DEBUG=true \
                  -v ~/.aws:/home/user/.aws \
                  -v `pwd`:/data \
                  -w /data/uat \
-                 --rm unifio/packer validate -var version=${CIRCLE_BUILD_NUM} uat-aws.json
+                 unifio/packer validate -var version=${CIRCLE_BUILD_NUM} uat-aws.json
     - |
-      docker run --volumes-from gems \
-                 -e "GEM_HOME=/ruby_gems" \
-                 -e "PATH=$PATH:/ruby_gems/bin" \
+      docker run -e "PATH=$PATH:/ruby_gems/bin" \
                  -e LOCAL_USER_ID=$UID \
                  -e DEBUG=true \
                  -v ~/.aws:/home/user/.aws \
                  -v `pwd`:/data \
                  -v /var/run/docker.sock:/var/run/docker.sock \
                  -w /data/uat \
-                 --rm unifio/packer build -var version=${CIRCLE_BUILD_NUM} uat-aws.json
+                 unifio/packer build -var version=${CIRCLE_BUILD_NUM} uat-aws.json
     - test -O uat/packer-container-uat.box
     - |
       docker run -v `pwd`:/data \
                  -v /var/run/docker.sock:/var/run/docker.sock \
                  -w /data/uat \
-                 --rm unifio/packer build uat-docker.json
+                 unifio/packer build uat-docker.json
     - "! test -O uat/image.tar"
 
 deployment:

--- a/uat/Gemfile
+++ b/uat/Gemfile
@@ -1,5 +1,0 @@
-source "http://rubygems.org"
-
-gem "rake"
-gem "serverspec"
-gem "json"

--- a/uat/Rakefile
+++ b/uat/Rakefile
@@ -1,6 +1,5 @@
 require 'rake'
 require 'rspec/core/rake_task'
-require 'bundler/setup'
 
 task :serverspec => 'serverspec:all'
 task :default => :serverspec

--- a/uat/uat-aws.json
+++ b/uat/uat-aws.json
@@ -17,8 +17,7 @@
     "type": "serverspec",
     "user": "root",
     "rake_file": "Rakefile",
-    "rake_task": "serverspec:all",
-    "rake_env_vars": "$BUNDLE_GEMFILE=Gemfile"
+    "rake_task": "serverspec:all"
   }],
   "post-processors": [[
     {


### PR DESCRIPTION
`rake`, `rspec`, `serverspec` are minimal required gems needed to get
serverspec to run natively within the docker container. This is required
if we're using this packer image to run the
`packer-provisioner-serverspec` plugin.
