### PR TITLE
Updated Packer, CircleCI config, Alpine base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.4
+FROM alpine:3.5
 MAINTAINER "Unif.io, Inc. <support@unif.io>"
 
-ENV PACKER_VERSION 0.12.0
+ENV PACKER_VERSION 0.12.2
 
 # This is the release of https://github.com/hashicorp/docker-base to pull in order
 # to provide HashiCorp-built versions of basic utilities like dumb-init and gosu.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Packer is a tool for creating machine and container images for multiple platform
 
 ## Dockerfile
 
-This Docker image is based on the official [alpine:3.4](https://hub.docker.com/_/alpine/) base image.
+This Docker image is based on the official [alpine:3.5](https://hub.docker.com/_/alpine/) base image.
 
 ## Enhancements
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,7 @@
 machine:
   environment:
-    PKR_VERSION: 0.12.0
+    PKR_VERSION: 0.12.2
+    DOCKER_IMAGE: 'unifio/packer'
   services:
     - docker
 
@@ -10,34 +11,37 @@ dependencies:
   override:
     - docker info
     - if [[ -e ~/docker/image.tar ]]; then docker load --input ~/docker/image.tar; fi
-    - docker build -t unifio/packer .
-    - mkdir -p ~/docker; docker save unifio/packer > ~/docker/image.tar
+    - docker build --rm=false -t ${DOCKER_IMAGE} .
+    - mkdir -p ~/docker; docker save ${DOCKER_IMAGE} > ~/docker/image.tar
 
 test:
   override:
-    - docker run unifio/packer version
+    - docker run -e CHECKPOINT_DISABLE=1 ${DOCKER_IMAGE} version
     - |
       docker run -e LOCAL_USER_ID=$UID \
+                 -e CHECKPOINT_DISABLE=1 \
                  -e DEBUG=true \
                  -v ~/.aws:/home/user/.aws \
                  -v `pwd`:/data \
                  -w /data/uat \
-                 unifio/packer validate -var version=${CIRCLE_BUILD_NUM} uat-aws.json
+                 ${DOCKER_IMAGE} validate -var version=${CIRCLE_BUILD_NUM} uat-aws.json
     - |
       docker run -e "PATH=$PATH:/ruby_gems/bin" \
                  -e LOCAL_USER_ID=$UID \
+                 -e CHECKPOINT_DISABLE=1 \
                  -e DEBUG=true \
                  -v ~/.aws:/home/user/.aws \
                  -v `pwd`:/data \
                  -v /var/run/docker.sock:/var/run/docker.sock \
                  -w /data/uat \
-                 unifio/packer build -var version=${CIRCLE_BUILD_NUM} uat-aws.json
+                 ${DOCKER_IMAGE} build -var version=${CIRCLE_BUILD_NUM} uat-aws.json
     - test -O uat/packer-container-uat.box
     - |
       docker run -v `pwd`:/data \
                  -v /var/run/docker.sock:/var/run/docker.sock \
                  -w /data/uat \
-                 unifio/packer build uat-docker.json
+                 -e CHECKPOINT_DISABLE=1 \
+                 ${DOCKER_IMAGE} build uat-docker.json
     - "! test -O uat/image.tar"
 
 deployment:
@@ -45,5 +49,5 @@ deployment:
     branch: master
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-      - docker tag -f `docker images | grep -E 'unifio/packer' | awk '{print $3}'` unifio/packer:${PKR_VERSION}
-      - docker push unifio/packer
+      - docker tag -f `docker images | grep -E "${DOCKER_IMAGE}" | awk '{print $3}'` ${DOCKER_IMAGE}:${PKR_VERSION}
+      - docker push ${DOCKER_IMAGE}


### PR DESCRIPTION
- Updated packer to version 0.12.2
- Updated Circle.yml file to
   - ignore errors with intermediary containers as [suggested by circleci documentation](https://circleci.com/docs/docker/#deployment-to-a-docker-registry)
   - use variable DOCKER_IMAGE rather then manually using image name.
   - Added CHECKPOINT_DISABLE to commands to speed up process and avoid un-needed calls to hashicorp version checking.
- Updated README to reflect alpine 3.5 as base image.